### PR TITLE
Add SDRaceMode scaffolding with recording, EV control, disclaimer, and UI

### DIFF
--- a/selfdrive/sdracemode/__init__.py
+++ b/selfdrive/sdracemode/__init__.py
@@ -1,0 +1,4 @@
+"""SDRaceMode package initialization."""
+from .sdracemode import SDRaceMode
+
+__all__ = ["SDRaceMode"]

--- a/selfdrive/sdracemode/sdracemode.py
+++ b/selfdrive/sdracemode/sdracemode.py
@@ -1,0 +1,95 @@
+"""Main activation logic for SDRaceMode."""
+from __future__ import annotations
+import json
+import os
+import time
+from typing import Optional
+
+from common.params import Params
+
+from .sdracemode_disclaimer import ensure_disclaimer
+from .sdracemode_recorder import SDRaceModeRecorder
+from .sdracemode_ui import SDRaceModeUI
+from .sdracemode_evcontrols import EVController
+from .sdracemode_settings import SettingsManager
+
+
+class SDRaceMode:
+    """Coordinates SDRaceMode components."""
+    def __init__(self) -> None:
+        self.params = Params()
+        self.settings_manager = SettingsManager()
+        self.settings = self.settings_manager.load()
+        self.ui = SDRaceModeUI()
+        self.recorder = SDRaceModeRecorder()
+        self.ev_controller = EVController()
+        self.running = False
+        self.start_time: Optional[float] = None
+        self.start_time_100: Optional[float] = None
+        self.results = {
+            "0_60": None,
+            "0_100": None,
+            "100_200": None,
+            "peak_torque": 0.0,
+            "peak_power": 0.0,
+            "g_force_max": 0.0,
+        }
+
+    def start(self) -> bool:
+        if not self.settings.enable:
+            return False
+        if not ensure_disclaimer():
+            return False
+        self.ev_controller.apply_settings()
+        self.recorder.start()
+        self.ui.start()
+        self.running = True
+        self.start_time = time.time()
+        return True
+
+    def update(self, speed_kph: float, torque_nm: float, power_kw: float, g_force: float) -> None:
+        if not self.running:
+            return
+        now = time.time()
+        if self.start_time is None:
+            self.start_time = now
+        elapsed = now - self.start_time
+        if speed_kph >= 60 and self.results["0_60"] is None:
+            self.results["0_60"] = elapsed
+        if speed_kph >= 100 and self.results["0_100"] is None:
+            self.results["0_100"] = elapsed
+            if self.start_time_100 is None:
+                self.start_time_100 = now
+        if speed_kph >= 200 and self.results["100_200"] is None and self.start_time_100 is not None:
+            self.results["100_200"] = now - self.start_time_100
+        self.results["peak_torque"] = max(self.results["peak_torque"], torque_nm)
+        self.results["peak_power"] = max(self.results["peak_power"], power_kw)
+        self.results["g_force_max"] = max(self.results["g_force_max"], g_force)
+        self.ui.update(speed_kph, g_force, power_kw, torque_nm,
+                       self.results["0_60"], self.results["0_100"], self.results["100_200"])
+
+    def stop(self) -> None:
+        if not self.running:
+            return
+        self.running = False
+        video_path = self.recorder.stop()
+        self.ui.stop()
+        end_time = time.time()
+        total_duration = None
+        if self.start_time is not None:
+            total_duration = end_time - self.start_time
+        session = {
+            "0_60_kph": self.results["0_60"],
+            "0_100_kph": self.results["0_100"],
+            "100_200_kph": self.results["100_200"],
+            "peak_torque_nm": self.results["peak_torque"],
+            "peak_power_kw": self.results["peak_power"],
+            "g_force_max": self.results["g_force_max"],
+            "total_duration_s": total_duration,
+            "video": video_path,
+        }
+        os.makedirs("/data/sdracemode/sessions", exist_ok=True)
+        ts = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+        session_file = f"/data/sdracemode/sessions/{ts}.json"
+        with open(session_file, "w", encoding="utf-8") as f:
+            json.dump(session, f, indent=2)

--- a/selfdrive/sdracemode/sdracemode_disclaimer.py
+++ b/selfdrive/sdracemode/sdracemode_disclaimer.py
@@ -1,0 +1,22 @@
+"""SDRaceMode disclaimer screen."""
+from __future__ import annotations
+from common.params import Params
+
+def ensure_disclaimer() -> bool:
+    """Show disclaimer text on first run and require acceptance."""
+    params = Params()
+    if params.get_bool("SDRaceModeAccepted"):
+        return True
+    # In the real system this would display a full screen dialog. Here we simply
+    # log the message and assume acceptance for demonstration purposes.
+    disclaimer = (
+        "SDRaceMode – Terms of Use\n\n"
+        "By using SDRaceMode, you confirm that:\n"
+        "• You will only use it in private or legal areas (e.g., race tracks)\n"
+        "• You accept full responsibility for any outcomes\n"
+        "• You understand this mode may disable vehicle safety features\n"
+        "• You acknowledge it is illegal to use on public roads\n"
+    )
+    print(disclaimer)
+    params.put("SDRaceModeAccepted", "1")
+    return True

--- a/selfdrive/sdracemode/sdracemode_evcontrols.py
+++ b/selfdrive/sdracemode/sdracemode_evcontrols.py
@@ -1,0 +1,19 @@
+"""EV specific control helpers for SDRaceMode."""
+from __future__ import annotations
+from common.params import Params
+
+
+class EVController:
+    """Simple parameter based EV control implementation."""
+    def __init__(self) -> None:
+        self.params = Params()
+
+    def apply_settings(self) -> None:
+        """Send settings to the car via Params for external processes to consume."""
+        settings = {
+            "drift_mode": self.params.get_bool("SDRM_DriftMode"),
+            "torque_split": self.params.get("SDRM_TorqueSplit") or "0:100",
+            "disable_front_motor": self.params.get_bool("SDRM_DisableFrontMotor"),
+            "disable_traction_control": self.params.get_bool("SDRM_DisableTraction"),
+        }
+        self.params.put("SDRaceModeEVSettings", str(settings))

--- a/selfdrive/sdracemode/sdracemode_recorder.py
+++ b/selfdrive/sdracemode/sdracemode_recorder.py
@@ -1,0 +1,37 @@
+"""Video and audio recording utilities for SDRaceMode."""
+from __future__ import annotations
+import os
+import time
+from typing import Optional
+
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover
+    cv2 = None
+
+
+class SDRaceModeRecorder:
+    """Simple video recorder using OpenCV if available."""
+    def __init__(self, out_dir: str = "/data/sdracemode/videos") -> None:
+        self.out_dir = out_dir
+        self.writer: Optional["cv2.VideoWriter"] = None
+        self.out_file: Optional[str] = None
+
+    def start(self) -> None:
+        os.makedirs(self.out_dir, exist_ok=True)
+        timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+        self.out_file = os.path.join(self.out_dir, f"{timestamp}.mp4")
+        if cv2 is None:
+            return
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        self.writer = cv2.VideoWriter(self.out_file, fourcc, 20.0, (640, 480))
+
+    def write_frame(self, frame) -> None:
+        if self.writer is not None:
+            self.writer.write(frame)
+
+    def stop(self) -> Optional[str]:
+        if self.writer is not None:
+            self.writer.release()
+            self.writer = None
+        return self.out_file

--- a/selfdrive/sdracemode/sdracemode_settings.py
+++ b/selfdrive/sdracemode/sdracemode_settings.py
@@ -1,0 +1,52 @@
+"""Settings management for SDRaceMode."""
+from __future__ import annotations
+from dataclasses import dataclass
+from common.params import Params
+
+
+@dataclass
+class SDRaceModeSettings:
+    enable: bool = False
+    power_unit: str = "HP"
+    record_audio: bool = True
+    video_quality: str = "High"
+    auto_start: bool = False
+    show_g_force: bool = True
+    drift_mode: bool = False
+    torque_split: str = "50:50"
+    disable_front_motor: bool = False
+    disable_traction: bool = False
+
+
+class SettingsManager:
+    """Persist settings via Params."""
+    def __init__(self) -> None:
+        self.params = Params()
+
+    def load(self) -> SDRaceModeSettings:
+        p = self.params
+        return SDRaceModeSettings(
+            enable=p.get_bool("SDRM_Enable"),
+            power_unit=p.get("SDRM_PowerUnit") or "HP",
+            record_audio=p.get_bool("SDRM_RecordAudio"),
+            video_quality=p.get("SDRM_VideoQuality") or "High",
+            auto_start=p.get_bool("SDRM_AutoStart"),
+            show_g_force=p.get_bool("SDRM_ShowGForce"),
+            drift_mode=p.get_bool("SDRM_DriftMode"),
+            torque_split=p.get("SDRM_TorqueSplit") or "50:50",
+            disable_front_motor=p.get_bool("SDRM_DisableFrontMotor"),
+            disable_traction=p.get_bool("SDRM_DisableTraction"),
+        )
+
+    def save(self, settings: SDRaceModeSettings) -> None:
+        p = self.params
+        p.put_bool("SDRM_Enable", settings.enable)
+        p.put("SDRM_PowerUnit", settings.power_unit)
+        p.put_bool("SDRM_RecordAudio", settings.record_audio)
+        p.put("SDRM_VideoQuality", settings.video_quality)
+        p.put_bool("SDRM_AutoStart", settings.auto_start)
+        p.put_bool("SDRM_ShowGForce", settings.show_g_force)
+        p.put_bool("SDRM_DriftMode", settings.drift_mode)
+        p.put("SDRM_TorqueSplit", settings.torque_split)
+        p.put_bool("SDRM_DisableFrontMotor", settings.disable_front_motor)
+        p.put_bool("SDRM_DisableTraction", settings.disable_traction)

--- a/selfdrive/sdracemode/sdracemode_ui.py
+++ b/selfdrive/sdracemode/sdracemode_ui.py
@@ -1,0 +1,41 @@
+"""User interface elements for SDRaceMode."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class HUDData:
+    speed: float = 0.0
+    g_force: float = 0.0
+    power: float = 0.0
+    torque: float = 0.0
+    timer_0_60: Optional[float] = None
+    timer_0_100: Optional[float] = None
+    timer_100_200: Optional[float] = None
+
+
+class SDRaceModeUI:
+    """Placeholder HUD overlay implementation."""
+    def __init__(self) -> None:
+        self.hud_data = HUDData()
+        self.active = False
+
+    def start(self) -> None:
+        self.active = True
+
+    def update(self, speed: float, g_force: float, power: float, torque: float,
+               timer_0_60: Optional[float], timer_0_100: Optional[float],
+               timer_100_200: Optional[float]) -> None:
+        if not self.active:
+            return
+        self.hud_data.speed = speed
+        self.hud_data.g_force = g_force
+        self.hud_data.power = power
+        self.hud_data.torque = torque
+        self.hud_data.timer_0_60 = timer_0_60
+        self.hud_data.timer_0_100 = timer_0_100
+        self.hud_data.timer_100_200 = timer_100_200
+
+    def stop(self) -> None:
+        self.active = False


### PR DESCRIPTION
## Summary
- set up basic SDRaceMode package and components
- add placeholder UI, recorder, EV controls, settings, and disclaimer

## Testing
- `pre-commit run --files selfdrive/sdracemode/__init__.py selfdrive/sdracemode/sdracemode.py selfdrive/sdracemode/sdracemode_ui.py selfdrive/sdracemode/sdracemode_recorder.py selfdrive/sdracemode/sdracemode_settings.py selfdrive/sdracemode/sdracemode_evcontrols.py selfdrive/sdracemode/sdracemode_disclaimer.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest -q selfdrive/sdracemode` *(fails: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb4962b883289f5206a8c98dd4e2